### PR TITLE
Support pour Home Assistant + amélioriations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 config.json
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 config.json
 *.log
+error.png

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,123 @@
+---
+files: ^(.*\.(py|json|md|sh|yaml|cfg|txt))$
+exclude: ^(\.[^/]*cache/.*)$
+repos:
+  - repo: https://github.com/executablebooks/mdformat
+    # Do this before other tools "fixing" the line endings
+    rev: 0.7.14
+    hooks:
+      - id: mdformat
+        stages: [manual]  # Require to run this manually
+        name: Format Markdown
+        entry: mdformat  # Executable to run, with fixed options
+        language: python
+        types: [markdown]
+        args: [--wrap, '75', --number]
+        additional_dependencies:
+          - mdformat-toc
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.2.0
+    hooks:
+      - id: no-commit-to-branch
+        args: [--branch, main]
+      - id: check-yaml
+        args: [--unsafe]
+      - id: debug-statements
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-json
+      - id: mixed-line-ending
+      - id: check-builtin-literals
+      - id: check-ast
+      - id: check-merge-conflict
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
+      - id: check-docstring-first
+      - id: fix-byte-order-marker
+      - id: check-case-conflict
+      # - id: check-toml
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.26.3
+    hooks:
+      - id: yamllint
+        args:
+          - --no-warnings
+          - -d
+          - '{extends: relaxed, rules: {line-length: {max: 90}}}'
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.32.1
+    hooks:
+      - id: pyupgrade
+        stages: [manual]  # Require to run this manually
+        args:
+          - --py37-plus
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        stages: [manual]  # Require to run this manually
+        args:
+          - --safe
+          - --quiet
+          - -l 79
+  - repo: https://github.com/Lucas-C/pre-commit-hooks-bandit
+    rev: v1.0.6
+    hooks:
+      - id: python-bandit-vulnerability-check
+        args: [--skip, 'B110,B404,B603', --recursive, .]
+
+  - repo: https://github.com/fsouza/autoflake8
+    rev: v0.3.2
+    hooks:
+      - id: autoflake8
+        stages: [manual]  # Require to run this manually
+        args:
+          - -i
+          - -r
+          - --expand-star-imports
+          - custom_components
+  - repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+        stages: [manual]  # Require to run this manually
+        additional_dependencies:
+          - pyproject-flake8==0.0.1a2
+          - flake8-bugbear==22.1.11
+          - flake8-comprehensions==3.8.0
+          - flake8_2020==1.6.1
+          - mccabe==0.6.1
+          - pycodestyle==2.8.0
+          - pyflakes==2.4.0
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        stages: [manual]  # Require to run this manually
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.1.0
+    hooks:
+      - id: codespell
+        stages: [manual]  # Require to run this manually
+        args:
+          - --ignore-words-list=hass
+          - --skip="./.*"
+          - --quiet-level=2
+  - repo: https://github.com/pre-commit/mirrors-pylint
+    rev: v3.0.0a4
+    hooks:
+      - id: pylint
+        args:
+          - --reports=no
+        #exclude: ^$
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.960
+    hooks:
+      - id: mypy
+        args:
+          - --ignore-missing-imports
+          - --install-types
+          - --non-interactive
+          - --check-untyped-defs
+          - --show-error-codes
+          - --show-error-context

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+## Start from the official Ubuntu image
+FROM ubuntu:21.04
+
+LABEL maintainer="MDW <MDW@private.fr>"
+
+## Set environment variables
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+
+# Not on 22.04:        firefox-geckodriver
+
+RUN export DEBIAN_FRONTEND="noninteractive" \
+    && apt-get update --fix-missing \
+    && apt-get upgrade -y \
+    && apt-get dist-upgrade -y \
+    && apt-get install -y \
+        firefox \
+        firefox-geckodriver \
+        xvfb \
+        xserver-xephyr \
+        python3-pip \
+        python3-selenium \
+        python3-pyvirtualdisplay \
+        python3-colorama \
+        python3-urllib3 \
+    && apt clean && apt autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
+
+
+# Install packages to Python3
+RUN pip3 install --upgrade pip \
+    && pip3 install \
+       "urllib3>=1.24.2" \
+       "colorama>=0.3.7" \
+       "selenium>=3.14.1" \
+       "PyVirtualDisplay>=0.2.4"

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,5 @@ RUN pip3 install --upgrade pip \
        "urllib3>=1.24.2" \
        "colorama>=0.3.7" \
        "selenium>=3.14.1" \
-       "PyVirtualDisplay>=0.2.4"
+       "PyVirtualDisplay>=0.2.4" \
+       "requests>=2.23.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,13 @@ ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
 # Not on 22.04:        firefox-geckodriver
 
+
+# Next lines would upgrade image - skipping
+#    && apt-get upgrade -y \
+#    && apt-get dist-upgrade -y \
+
 RUN export DEBIAN_FRONTEND="noninteractive" \
     && apt-get update --fix-missing \
-    && apt-get upgrade -y \
-    && apt-get dist-upgrade -y \
     && apt-get install -y \
         firefox \
         firefox-geckodriver \
@@ -22,15 +25,16 @@ RUN export DEBIAN_FRONTEND="noninteractive" \
         python3-pyvirtualdisplay \
         python3-colorama \
         python3-urllib3 \
+        python3-requests \
     && apt clean && apt autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
 
 # Install packages to Python3
-RUN pip3 install --upgrade pip \
-    && pip3 install \
-       "urllib3>=1.24.2" \
-       "colorama>=0.3.7" \
-       "selenium>=3.14.1" \
-       "PyVirtualDisplay>=0.2.4" \
-       "requests>=2.23.0"
+# RUN pip3 install --upgrade pip \
+#     && pip3 install \
+#        "urllib3>=1.24.2" \
+#        "colorama>=0.3.7" \
+#        "selenium>=3.14.1" \
+#        "PyVirtualDisplay>=0.2.4" \
+#        "requests>=2.23.0"

--- a/DockerfileAlpine
+++ b/DockerfileAlpine
@@ -1,0 +1,35 @@
+## Start from the official Alpine image
+FROM alpine:3.16
+
+LABEL maintainer="MDW <MDW@private.fr>"
+
+## Set environment variables
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+
+# Not on Debian: firefox firefox-geckodriver
+
+RUN apk add \
+        py-urllib3 \
+        py3-colorama \
+        xvfb \
+        py3-pip \
+        xorg-server-xephyr \
+        chromium-chromedriver \
+        chromium \
+        py3-openssl \
+        py3-pysocks \
+        py3-wsproto \
+        py3-sniffio \
+        py3-async_generator \
+        py3-sortedcontainers \
+        py3-attrs \
+        py3-outcome \
+        py3-trio \
+  && pip install \
+        'urllib3>=1.24.2' \
+        'colorama>=0.3.7' \
+        'selenium>=3.14.1' \
+        'PyVirtualDisplay>=0.2.4' \
+        'requests>=2.23.0'
+
+

--- a/DockerfileDebian
+++ b/DockerfileDebian
@@ -17,6 +17,7 @@ RUN export DEBIAN_FRONTEND="noninteractive" \
         xauth \
         xserver-xephyr \
         chromium-driver \
+        chromium \ 
         python3-pip \
         python3-selenium \
         python3-pyvirtualdisplay \

--- a/DockerfileDebian
+++ b/DockerfileDebian
@@ -1,4 +1,4 @@
-## Start from the official Ubuntu image
+## Start from the official Debian image
 FROM debian:bullseye
 
 LABEL maintainer="MDW <MDW@private.fr>"

--- a/DockerfileDebian
+++ b/DockerfileDebian
@@ -1,5 +1,5 @@
 ## Start from the official Ubuntu image
-FROM debian:buster
+FROM debian:bullseye
 
 LABEL maintainer="MDW <MDW@private.fr>"
 

--- a/DockerfileDebian
+++ b/DockerfileDebian
@@ -1,0 +1,27 @@
+## Start from the official Ubuntu image
+FROM debian:buster
+
+LABEL maintainer="MDW <MDW@private.fr>"
+
+## Set environment variables
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+
+# Not on Debian: firefox firefox-geckodriver
+
+RUN export DEBIAN_FRONTEND="noninteractive" \
+    && apt-get update --fix-missing \
+    && apt-get upgrade -y \
+    && apt-get dist-upgrade -y \
+    && apt-get install -y \
+        xvfb \
+        xauth \
+        xserver-xephyr \
+        chromium-driver \
+        python3-pip \
+        python3-selenium \
+        python3-pyvirtualdisplay \
+        python3-colorama \
+        python3-urllib3 \
+        python3-requests \
+    && apt clean && apt autoremove -y \
+    && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # veolia-idf
 Ce script automatise le chargement de l'historique de votre consommation d'eau récupèré sur le site de Veolia Ile-de-France dans la solution domotique Domoticz
 
-Ce script s'installe sur le serveur hébergeant l'applicatif domoticz ou sur autre. Son execution est manuelle ou peut se planifier à travers un planificateur de tâche tel que "cron". 
+Ce script s'installe sur le serveur hébergeant l'applicatif domoticz ou sur autre. Son execution est manuelle ou peut se planifier à travers un planificateur de tâche tel que "cron".
 
 La récuperation des données se fait grace à l'outil selenium et l'execution en mode Headless de firefox (simulation d'un utilisateur en tâche de fond sans mode graphique).
 
@@ -26,7 +26,7 @@ La récuperation des données se fait grace à l'outil selenium et l'execution e
   * colorama
   * urllib3
   * qq autres... (le script commence par verifier la présence des modules)
-* Un Virtual Sensor Domoticz 
+* Un Virtual Sensor Domoticz
 
 ## Tester sur ubuntu 20.04
 
@@ -43,7 +43,7 @@ apt install firefox firefox-geckodriver xvfb xserver-xephyr python3-selenium pyt
   * Type Counter : water
   * Counter Divider : 1000
   * Meter Offset : 0
-    
+
 ## Installation :
 
 Copier les fichiers veolia-idf-domoticz.py et config.json.exemple sur votre serveur. Comme par exemple en :
@@ -63,7 +63,7 @@ chmod ugo+x veolia-idf-domoticz.py
 ```
 Ajouter les prerequis python:
 ```shell
-pip3 install -r requirements.txt 
+pip3 install -r requirements.txt
 ```
 
 ## Configuration :
@@ -89,20 +89,20 @@ Si vous voyez bien une fenetre X s'afficher à l'écran c'est que l'environnemen
 Si par contre rien ne s'affiche, il convient de chercher sur internet comment le faire fonctionner, il y a pleins de tutos pour cela. Ensuite vous pourrez utiliser le mode debug.
 
 ## Première execution :
-Par default le script est muet (il n'affiche rien sur la console et ne lance pas la version graphique de Firefox). Il enregistre toutes les actions dans le fichier INSTALL_DIR/veolia.log . 
-Je vous recommande pour la première utilisation d'activer le mode debug. Cela permet d'avoir une sortie visuelle de l'éxecution du script sur la console et un suivi des actions dans Firefox. 
+Par default le script est muet (il n'affiche rien sur la console et ne lance pas la version graphique de Firefox). Il enregistre toutes les actions dans le fichier INSTALL_DIR/veolia.log .
+Je vous recommande pour la première utilisation d'activer le mode debug. Cela permet d'avoir une sortie visuelle de l'éxecution du script sur la console et un suivi des actions dans Firefox.
 
 Déroulement de l'éxécution :
 1/ Chargement de tous les modules python --> si erreur installer les modules manquants (pip3 install ...)
 2/ Sanity check de l'environnement :
  * Version
- * Pre-requis logiciel externe --> si erreur installer le logiciel manquant 
+ * Pre-requis logiciel externe --> si erreur installer le logiciel manquant
  * Configuration domoticz --> si erreur configurer correctement domoticz
 3/ Connection au site Veolia et téléchargement de l'historique
 4/ Téléversement des données dans domoticz
 
 ```shell
-./veolia-idf-domoticz.py --run --debug 
+./veolia-idf-domoticz.py --run --debug
 ```
 Afficher toutes les options disponibles :
 ```shell
@@ -124,7 +124,7 @@ crontab -e
 ```shell
 
 ## Environnements testés:
-* Debian buster 
+* Debian buster
 * Ubuntu Zesty (17.04)
 
 ## Remerciements :

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ La récuperation des données se fait grace à l'outil selenium et l'execution e
 ## Tester sur ubuntu 20.04
 
 Sur ubuntu ca donne :
-```
+```shell
 apt install firefox firefox-geckodriver xvfb xserver-xephyr python3-selenium python3-pyvirtualdisplay python3-colorama python3-urllib3
 ```
 
@@ -47,28 +47,28 @@ apt install firefox firefox-geckodriver xvfb xserver-xephyr python3-selenium pyt
 ## Installation :
 
 Copier les fichiers veolia-idf-domoticz.py et config.json.exemple sur votre serveur. Comme par exemple en :
-```
+```shell
 mkdir -p /opt
 cd /opt
 git clone https://github.com/s0nik42/veolia-idf
 cd veolia-idf
 ```
 Pour mettre à jour :
-```
+```shell
 git pull
 ```
 Donnez la permission d'exécution si vous êtes sous Linux :
-```
+```shell
 chmod ugo+x veolia-idf-domoticz.py
 ```
 Ajouter les prerequis python:
-```
+```shell
 pip3 install -r requirements.txt 
 ```
 
 ## Configuration :
 Copier le fichier config.json.exemple en config.json
-```
+```shell
 cp  config.json.exemple config.json
 ```
 Modifier le contenu du fichier avec vos valeurs. les champs obligatoires sont :
@@ -80,9 +80,9 @@ Modifier le contenu du fichier avec vos valeurs. les champs obligatoires sont :
 
 ## Paramètrer votre système pour le mode debug (optionnel, mais recommandé)
 Si vous rencontrez des problèmes à l'execution, il sera utile d'utiliser le mode debug (--debug). 2 senarios :
-1/ Le script est executé en locale part l'utilisateur avec lequel vous êtes logués  ==> ca devrait fonctionner tout seul.
+1/ Le script est executé en locale par l'utilisateur avec lequel vous êtes logués  ==> ca devrait fonctionner tout seul.
 2/ Vous executez le script sur une machine distante linux. Il convient alors de vérifier que la commande suivante fonctionne apres être connecté sur la machine linux distante (via ssh probablement) :
-```xlogo```
+`xlogo`
 
 Si vous voyez bien une fenetre X s'afficher à l'écran c'est que l'environnement X11 est correctement configuré. Le mode debug du script devrait fonctionner.
 
@@ -101,25 +101,27 @@ Déroulement de l'éxécution :
 3/ Connection au site Veolia et téléchargement de l'historique
 4/ Téléversement des données dans domoticz
 
-```
+```shell
 ./veolia-idf-domoticz.py --run --debug 
 ```
 Afficher toutes les options disponibles :
-```
+```shell
 ./veolia-idf-domoticz.py --help
 ```
 
 ## Automatisation :
 Une fois que la première execution à terminée correctement, je vous recommande de planifier les executions une fois par jour. En rajoutant la ligne suivante à votre planificateur de tâche :
-```
+```shell
 ./veolia-idf-domoticz.py --run
 ```
 
 exemple ici crontab :
-```
+```shell
 crontab -e
 ```
+```crontab
 0 1 * * *       /opt/veolia-idf/veolia-idf-domoticz.py --run --log /var/log/veolia/veolia-idf.log
+```shell
 
 ## Environnements testés:
 * Debian buster 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Modifier le contenu du fichier avec vos valeurs. les champs obligatoires sont :
 * "domoticz_idx": le numero du "virtual sensor" domoticz crée (se trouve dans : Domoticz/Devices/[Colonne Idx]
 
 ## Paramètrer votre système pour le mode debug (optionnel, mais recommandé)
-Si vous rencontrez des problèmes à l'execution, il sera utile d'utiliser le mode debug (--debug). 2 senarios :
+Si vous rencontrez des problèmes à l'execution, il sera utile d'utiliser le mode debug (--debug). 2 scenarios :
 1/ Le script est executé en locale par l'utilisateur avec lequel vous êtes logués  ==> ca devrait fonctionner tout seul.
 2/ Vous executez le script sur une machine distante linux. Il convient alors de vérifier que la commande suivante fonctionne apres être connecté sur la machine linux distante (via ssh probablement) :
 `xlogo`

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ crontab -e
 ```
 ```crontab
 0 1 * * *       /opt/veolia-idf/veolia-idf-domoticz.py --run --log /var/log/veolia/veolia-idf.log
-```shell
+```
 
 ## Environnements testés:
 * Debian buster

--- a/config.json.exemple.home-assistant
+++ b/config.json.exemple.home-assistant
@@ -1,7 +1,6 @@
 {
     "veolia_login": "monadresse@email.fr",
     "veolia_password": "GretaThunberg",
-    "veolia_contract": "6402275",
     "veolia_contract": "MONNUMEROCONTRTAT",
     "ha_server": "http://SERVER:PORT",
     "ha_token": "MONTOKEN - voir https://my.home-assistant.io/redirect/profile/ - Jetons d'accès de longue durée",

--- a/config.json.exemple.home-assistant
+++ b/config.json.exemple.home-assistant
@@ -1,0 +1,10 @@
+{
+    "veolia_login": "monadresse@email.fr",
+    "veolia_password": "GretaThunberg",
+    "veolia_contract": "6402275",
+    "veolia_contract": "MONNUMEROCONTRTAT",
+    "ha_server": "http://SERVER:PORT",
+    "ha_token": "MONTOKEN - voir https://my.home-assistant.io/redirect/profile/ - Jetons d'accès de longue durée",
+    "type": "ha",
+    "timeout": "30" 
+}

--- a/dockerAlpineRun.BAT
+++ b/dockerAlpineRun.BAT
@@ -1,0 +1,17 @@
+@ECHO OFF
+
+REM Run veolia-idf in Docker container 
+
+SET IMAGE=py-veolia-alpine
+
+REM BUILD DOCKER CONTAINER
+docker build --rm -t %IMAGE% -f ./DockerfileAlpine ./
+
+REM VcXsvr can provide an XServer on Windows
+SET DISPLAY=host.docker.internal:0.0
+SET ARGS=./veolia-idf-domoticz.py --run --debug
+
+REM This does not need an XServer
+SET ARGS=./veolia-idf-domoticz.py --run
+
+docker run --rm -it -e DISPLAY=%DISPLAY% -v %cd%:/root/workdir --env NO_AT_BRIDGE=1 --workdir="/root" %IMAGE% /bin/ash -c "cd workdir ; %ARGS%" 

--- a/dockerDebianRun.BAT
+++ b/dockerDebianRun.BAT
@@ -12,6 +12,6 @@ SET DISPLAY=host.docker.internal:0.0
 SET ARGS=./veolia-idf-domoticz.py --run --debug
 
 REM This does not need an XServer
-REM SET ARGS=./veolia-idf-domoticz.py --run
+SET ARGS=./veolia-idf-domoticz.py --run
 
 docker run --rm -it -e DISPLAY=%DISPLAY% -v %cd%:/root/workdir --env NO_AT_BRIDGE=1 --workdir="/root" %IMAGE% /bin/bash -c "cd workdir ; %ARGS%" 

--- a/dockerDebianRun.BAT
+++ b/dockerDebianRun.BAT
@@ -1,0 +1,17 @@
+@ECHO OFF
+
+REM Run veolia-idf in Docker container 
+
+SET IMAGE=py-veolia-debian
+
+REM BUILD DOCKER CONTAINER
+docker build --rm -t %IMAGE% -f ./DockerfileDebian ./
+
+REM VcXsvr can provide an XServer on Windows
+SET DISPLAY=host.docker.internal:0.0
+SET ARGS=./veolia-idf-domoticz.py --run --debug
+
+REM This does not need an XServer
+REM SET ARGS=./veolia-idf-domoticz.py --run
+
+docker run --rm -it -e DISPLAY=%DISPLAY% -v %cd%:/root/workdir --env NO_AT_BRIDGE=1 --workdir="/root" %IMAGE% /bin/bash -c "cd workdir ; %ARGS%" 

--- a/dockerRun.BAT
+++ b/dockerRun.BAT
@@ -1,0 +1,17 @@
+@ECHO OFF
+
+REM Run veolia-idf in Docker container 
+
+SET IMAGE=py-veolia
+
+REM BUILD DOCKER CONTAINER
+docker build --rm -t %IMAGE% -f ./Dockerfile ./
+
+REM VcXsvr can provide an XServer on Windows
+SET DISPLAY=host.docker.internal:0.0
+SET ARGS=./veolia-idf-domoticz.py --run --debug
+
+REM This does not need an XServer
+SET ARGS=./veolia-idf-domoticz.py --run
+
+docker run --rm -it -e DISPLAY=%DISPLAY% -v %cd%:/root/workdir --env NO_AT_BRIDGE=1 --workdir="/root" %IMAGE% /bin/bash -c "cd workdir ; %ARGS%" 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ urllib3>=1.24.2
 colorama>=0.3.7
 selenium>=3.14.1
 PyVirtualDisplay>=0.2.4
+requests>=2.23.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,25 @@
+[isort]
+profile = black
+line_length = 79
+
+[pylint.MESSAGES CONTROL]
+disable = 
+   too-few-public-methods,
+   too-many-lines,
+   too-many-branches,
+   too-many-statements,
+   consider-using-with,
+   pointless-statement,
+   raise-missing-from,
+   unused-private-member,
+   missing-class-docstring,
+   missing-function-docstring,
+   invalid-name,
+   broad-except,
+   bare-except,
+   try-except-raise,
+   no-else-raise,
+   line-too-long
+
+[pylint.FORMAT]
+max-line-length = 79

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ profile = black
 line_length = 79
 
 [pylint.MESSAGES CONTROL]
-disable = 
+disable =
    too-few-public-methods,
    too-many-lines,
    too-many-branches,

--- a/veolia-idf-domoticz.py
+++ b/veolia-idf-domoticz.py
@@ -2,7 +2,6 @@
 """
 @author: s0nik42
 """
-from __future__ import annotations
 # veolia-idf
 # Copyright (C) 2019 Julien NOEL
 #
@@ -85,7 +84,7 @@ class Output:
             try:
                 open(logfile, "a+").close()
             except Exception as e:
-                raise RuntimeError(f'"{logfile}" {e}')
+                raise RuntimeError('"%s" %s' % (logfile, e,))
 
             # Set the logfile format
             file_handler = RotatingFileHandler(logfile, "a", 1000000, 1)
@@ -105,7 +104,7 @@ class Output:
 
         if end is not None:
             st = st + " " if st else ""
-            print(st + f"{string:75s}", end="", flush=True)
+            print(st + "%75s" % (string,), end="", flush=True)
             self.__print_buffer = self.__print_buffer + string
         elif self.__print_buffer:
             st = st if st else "[--] "
@@ -181,7 +180,7 @@ class VeoliaCrawler:
         self.__browser = None  # type: webdriver.Firefox
         self.__wait = None  # type: WebDriverWait
         install_dir = os.path.dirname(os.path.realpath(__file__))
-        self.configuration: dict[str, str|None] = {
+        self.configuration = {
             # Mandatory config values
             "veolia_login": None,
             "veolia_password": None,
@@ -412,7 +411,7 @@ class VeoliaCrawler:
                 open(self.__full_path_download_file, "a+").close()
             except Exception as e:
                 raise RuntimeError(
-                    '"' + self.__full_path_download_file + f'" {e}'
+                    '"%s" %s' % (self.__full_path_download_file, e,)
                 )
             else:
                 self.print(st="ok")
@@ -839,7 +838,7 @@ class DomoticzInjector:
         # Supersede local print function if provided as an argument
         self.print = super_print if super_print else self.print
 
-        self.configuration: dict[str,str|int|None] = {
+        self.configuration = {
             # Mandatory config values
             "domoticz_idx": None,
             "domoticz_server": None,
@@ -919,7 +918,7 @@ class DomoticzInjector:
         return j
 
     # Load configuration items
-    def _load_configururation_items(self, config_dict: dict[str,str|int]):
+    def _load_configururation_items(self, config_dict):
         for param in list((self.configuration).keys()):
             if param not in config_dict:
                 if self.configuration[param] is not None:
@@ -1187,7 +1186,7 @@ class HomeAssistantInjector(DomoticzInjector):
         api_url = self.configuration["ha_server"] + uri
 
         headers = {
-            "Authorization": f"Bearer {self.configuration['ha_token']}",
+            "Authorization": "Bearer %s" % (self.configuration['ha_token'],),
             "Content-Type": "application/json",
         }
 
@@ -1198,7 +1197,7 @@ class HomeAssistantInjector(DomoticzInjector):
                 response = requests.post(api_url, headers=headers, json=data)
         except Exception as e:
             # HANDLE CONNECTIVITY ERROR
-            raise RuntimeError(f"url={api_url} : {e}")
+            raise RuntimeError("url=%s : %s" % (api_url, e,))
 
         # HANDLE SERVER ERROR CODE
         if response.status_code != 200:
@@ -1215,7 +1214,7 @@ class HomeAssistantInjector(DomoticzInjector):
             j = json.loads(response.content.decode("utf-8"))
         except Exception as e:
             # Handle JSON ERROR
-            raise RuntimeError(f"Unable to parse JSON : {e}")
+            raise RuntimeError("Unable to parse JSON : %s" % (e,))
 
         return j
 
@@ -1241,9 +1240,9 @@ class HomeAssistantInjector(DomoticzInjector):
                 d2 = datetime.now()
                 if abs((d2 - d1).days) > 30:
                     raise RuntimeError(
-                        f"File contains too old data (monthly?!?): {row}"
+                        "File contains too old data (monthly?!?): %s" % (row,)
                     )
-                self.print(f"    update value for {date}", end="")
+                self.print("    update value for %s" % (date,), end="")
                 data = {
                     "state": meter_total,
                     "attributes": {
@@ -1252,12 +1251,12 @@ class HomeAssistantInjector(DomoticzInjector):
                     },
                 }
                 self.open_url(
-                    f"/api/states/sensor.veolia_{self.configuration['veolia_contract']}_total",
+                    "/api/states/sensor.veolia_%s_total" % (self.configuration['veolia_contract'],),
                     data,
                 )
                 data["state"] = meter_period_total
                 self.open_url(
-                    f"/api/states/sencor.veolia_{self.configuration['veolia_contract']}_period_total",
+                    "/api/states/sensor.veolia_%s_period_total" % (self.configuration['veolia_contract'],),
                     data,
                 )
                 self.print(st="ok")
@@ -1266,7 +1265,6 @@ class HomeAssistantInjector(DomoticzInjector):
         pass
 
 
-o: Output
 def exit_on_error(veolia_obj=None, domoticz=None, string="", debug=False):
     try:
         o

--- a/veolia-idf-domoticz.py
+++ b/veolia-idf-domoticz.py
@@ -324,7 +324,7 @@ class VeoliaCrawler:
             # Enable the browser
             try:
                 self.__browser = webdriver.Firefox(
-                    options=opts,
+                    chrome_options=opts,
                     service_log_path=str(self.configuration["logs_folder"])
                     + "/geckodriver.log",
                     service=service,

--- a/veolia-idf-domoticz.py
+++ b/veolia-idf-domoticz.py
@@ -50,7 +50,7 @@ try:
     from selenium.webdriver.common.by import By
     from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
     from selenium.webdriver.firefox.options import Options
-    from selenium.webdriver.firefox.service import FirefoxService
+    from selenium.webdriver.firefox.service import Service as FirefoxService
     from selenium.webdriver.support import expected_conditions as EC
     from selenium.webdriver.support.ui import WebDriverWait
 except ImportError as exc:
@@ -327,7 +327,7 @@ class VeoliaCrawler:
             # Enable the browser
             try:
                 self.__browser = webdriver.Firefox(
-                    chrome_options=opts,
+                    options=opts,
                     service_log_path=str(self.configuration["logs_folder"])
                     + "/geckodriver.log",
                     service=service,
@@ -382,19 +382,15 @@ class VeoliaCrawler:
         else:
             options.add_argument("--headless")
             options.add_argument("--disable-gpu")
-            self.print("Before display", end="")
             try:
               self.__display = Display(visible=0, size=(1280, 1024))
-            except Exception as e:
-              print("%r" % (e))  
-              raise e
-            self.print("After display", end="")
+            except Exception:
+              raise
 
         try:
             self.__display.start()
-        except Exception as e:
-            print(str(e))
-            raise e
+        except Exception:
+            raise
         else:
             self.print(st="OK")
 
@@ -404,7 +400,7 @@ class VeoliaCrawler:
         try:
             self.__browser = webdriver.Chrome(
                 executable_path=self.configuration["chromedriver"],
-                options=options,
+                chrome_options=options,
             )
             self.__browser.maximize_window()
             self.__wait = WebDriverWait(

--- a/veolia-idf-domoticz.py
+++ b/veolia-idf-domoticz.py
@@ -1156,7 +1156,6 @@ class DomoticzInjector:
 
 
 class HomeAssistantInjector(DomoticzInjector):
-
     def __init__(self, config_dict, super_print, debug=False):
         # pylint: disable=super-init-not-called
         self.__debug = debug
@@ -1183,7 +1182,6 @@ class HomeAssistantInjector(DomoticzInjector):
         else:
             self.print(st="ok")
 
-
     def open_url(self, uri, data=None):
         # Generate URL
         api_url = self.configuration["ha_server"] + uri
@@ -1205,7 +1203,12 @@ class HomeAssistantInjector(DomoticzInjector):
         # HANDLE SERVER ERROR CODE
         if response.status_code != 200:
             raise RuntimeError(
-                "url=%s - (code = %u)\ncontent=%r)" % (api_url, response.status_code, response.content,)
+                "url=%s - (code = %u)\ncontent=%r)"
+                % (
+                    api_url,
+                    response.status_code,
+                    response.content,
+                )
             )
 
         try:
@@ -1216,16 +1219,11 @@ class HomeAssistantInjector(DomoticzInjector):
 
         return j
 
-
-
     def sanity_check(self, debug=False):
-        self.print(
-            "Check Home Assistant connectivity", st="--", end=""
-        )
+        self.print("Check Home Assistant connectivity", st="--", end="")
         response = self.open_url("/api/")
         if response["message"] == "API running":
             self.print(st="ok")
-
 
     def update_device(self, csv_file):
         self.print("Parsing csv file")
@@ -1245,18 +1243,24 @@ class HomeAssistantInjector(DomoticzInjector):
                     raise RuntimeError(
                         f"File contains too old data (monthly?!?): {row}"
                     )
-                self.print(
-                    f"    update value for {date}", end=""
-                )
+                self.print(f"    update value for {date}", end="")
                 data = {
-                    "state":meter_total,
-                    "attributes": { "date_time": date_time, "unit_of_measurement": "L", }
+                    "state": meter_total,
+                    "attributes": {
+                        "date_time": date_time,
+                        "unit_of_measurement": "L",
+                    },
                 }
-                self.open_url(f"/api/states/sensor.veolia_{self.configuration['veolia_contract']}_total", data)
+                self.open_url(
+                    f"/api/states/sensor.veolia_{self.configuration['veolia_contract']}_total",
+                    data,
+                )
                 data["state"] = meter_period_total
-                self.open_url(f"/api/states/sencor.veolia_{self.configuration['veolia_contract']}_period_total", data)
+                self.open_url(
+                    f"/api/states/sencor.veolia_{self.configuration['veolia_contract']}_period_total",
+                    data,
+                )
                 self.print(st="ok")
-
 
     def clean_up(self, debug=False):
         pass

--- a/veolia-idf-domoticz.py
+++ b/veolia-idf-domoticz.py
@@ -451,7 +451,7 @@ class VeoliaCrawler:
             self.print(st="ok")
 
         self.print(
-            'Check if "geckodriver"+"firefox" or "chromedriver"+"chrome" is installed properly', end=""
+            'Check availabilty of "geckodriver"+"firefox" or "chromedriver"+"chromium"', end=""
 
         )  #############################################################
         if ( os.access(str(self.configuration["geckodriver"]), os.X_OK) and

--- a/veolia-idf-domoticz.py
+++ b/veolia-idf-domoticz.py
@@ -841,6 +841,13 @@ class VeoliaCrawler:
         if os.path.exists(self.__full_path_download_file):
             self.print(st="ok")
         else:
+            try:
+                error_img = "%serror.png" % (self.configuration["logs_folder"],)
+                self.print( "Get & Save '%s'" % (error_img,), end="")
+                # img = self.__display.waitgrab()
+                self.__browser.get_screenshot_as_file(error_img)
+            except Exception as e:
+                self.print( "Exception while getting image: %s" % (e,), end="")
             raise RuntimeError("File download timeout")
 
         return self.__full_path_download_file

--- a/veolia-idf-domoticz.py
+++ b/veolia-idf-domoticz.py
@@ -50,7 +50,7 @@ try:
     from selenium.webdriver.common.by import By
     from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
     from selenium.webdriver.firefox.options import Options
-    from selenium.webdriver.firefox.service import Service
+    from selenium.webdriver.firefox.service import FirefoxService
     from selenium.webdriver.support import expected_conditions as EC
     from selenium.webdriver.support.ui import WebDriverWait
 except ImportError as exc:
@@ -319,7 +319,10 @@ class VeoliaCrawler:
             # Set firefox binary to use
             opts.binary_location = FirefoxBinary(str(self.configuration["firefox"]))
 
-            service = Service(self.configuration["geckodriver"])
+            service = FirefoxService(self.configuration["geckodriver"])
+            if not hasattr(service, 'process'):
+                # Webdriver may complain about missing process.
+                service.process = None
 
             # Enable the browser
             try:

--- a/veolia-idf-domoticz.py
+++ b/veolia-idf-domoticz.py
@@ -104,7 +104,7 @@ class Output:
 
         if end is not None:
             st = st + " " if st else ""
-            print(st + "%75s" % (string,), end="", flush=True)
+            print(st + "%-75s" % (string,), end="", flush=True)
             self.__print_buffer = self.__print_buffer + string
         elif self.__print_buffer:
             st = st if st else "[--] "
@@ -197,6 +197,7 @@ class VeoliaCrawler:
             else install_dir + "/firefox",
             "chromium": which("chromium")
             if which("chromium")
+            else which("chromium-browser") if which("chromium-browser")
             else install_dir + "/chromium",
             "chromedriver": which("chromedriver")
             if which("chromedriver")

--- a/veolia-idf-domoticz.py
+++ b/veolia-idf-domoticz.py
@@ -366,12 +366,15 @@ class VeoliaCrawler:
         options.add_argument("--disable-renderer-backgrounding")
         options.add_argument("--disable-background-timer-throttling")
         options.add_argument("--disable-backgrounding-occluded-wndows")
+        options.add_argument("--disable-translate")
+        options.add_argument("--disable-popup-blocking")
         options.add_experimental_option(
             "prefs",
             {
                 "download.default_directory": self.configuration[
                     "download_folder"
                 ],
+                "profile.default_content_settings.popups": 0,
                 "download.prompt_for_download": False,
                 "download.directory_upgrade": True,
                 "extensions_to_open": "text/csv",
@@ -800,8 +803,8 @@ class VeoliaCrawler:
             "Wait for button telechargement", end=""
         )  #############################################################
         try:
-            ep = EC.presence_of_element_located(
-                (By.XPATH, '//*[contains(text(),"charger la p")]')
+            ep = EC.visibility_of_element_located(
+                (By.XPATH, '//button[contains(text(),"charger la p")]')
             )
             el = self.__wait.until(
                 ep,
@@ -817,8 +820,9 @@ class VeoliaCrawler:
         self.print(
             "Wait before clicking (10)", end=""
         )  #############################################################
+        self.print(st="~~")
+
         time.sleep(10)
-        self.print(st="ok")
 
         self.print(
             "Click on button telechargement", end=""

--- a/veolia-idf-domoticz.py
+++ b/veolia-idf-domoticz.py
@@ -793,7 +793,7 @@ class VeoliaCrawler:
             self.print(st="ok")
 
         self.print(
-            "Wait for button téléchargement", end=""
+            "Wait for button telechargement", end=""
         )  #############################################################
         try:
             ep = EC.presence_of_element_located(
@@ -817,7 +817,7 @@ class VeoliaCrawler:
         self.print(st="ok")
 
         self.print(
-            "Click on button téléchargement", end=""
+            "Click on button telechargement", end=""
         )  #############################################################
         try:
             el.click()

--- a/veolia-idf-domoticz.py
+++ b/veolia-idf-domoticz.py
@@ -398,7 +398,7 @@ class VeoliaCrawler:
         else:
             self.print(st="OK")
 
-    def sanity_check(self):
+    def sanity_check(self, debug=False):
 
         self.print(
             "Check download location integrity", end=""
@@ -431,7 +431,7 @@ class VeoliaCrawler:
 
         self.print(
             'Check if "geckodriver" is installed properly', end=""
-    
+
         )  #############################################################
         if os.access(self.configuration["geckodriver"], os.X_OK):
             self.print(st="ok")
@@ -491,7 +491,7 @@ class VeoliaCrawler:
 
         return major, minor
 
-    def clean_up(self):
+    def clean_up(self, debug=False):
         self.print(
             "Close Browser", end=""
         )  #############################################################
@@ -527,7 +527,7 @@ class VeoliaCrawler:
             if not debug and os.path.exists(self.__full_path_download_file):
                 #############################################################
                 # Remove file
-                self.print( "Remove downloaded file " + self.download_filename, end="")  
+                self.print( "Remove downloaded file " + self.download_filename, end="")
                 os.remove(self.__full_path_download_file)
             else:
                 self.print(st="ok")
@@ -975,7 +975,7 @@ class DomoticzInjector:
 
                 self.print(st="OK")
 
-    def sanity_check(self):
+    def sanity_check(self, debug=False):
         self.print(
             "Check domoticz connectivity", end=""
         )  #############################################################
@@ -1155,11 +1155,11 @@ class DomoticzInjector:
             self.print(st="ok")
 
 
-    def clean_up(self):
+    def clean_up(self, debug=False):
         pass
 
 
-def exit_on_error(veolia=None, domoticz=None, string=""):
+def exit_on_error(veolia=None, domoticz=None, string="", debug=False):
     try:
         o
     except:
@@ -1168,9 +1168,9 @@ def exit_on_error(veolia=None, domoticz=None, string=""):
         o.print(string, st="EE")
 
     if veolia is not None:
-        veolia.clean_up()
+        veolia.clean_up(debug)
     if domoticz:
-        domoticz.clean_up()
+        domoticz.clean_up(debug)
     try:
         o
     except:
@@ -1294,12 +1294,12 @@ if __name__ == "__main__":
 
     # Check requirements
     try:
-        veolia.sanity_check()
+        veolia.sanity_check(args.debug)
     except Exception as e:
         exit_on_error(veolia, domoticz, str(e))
 
     try:
-        domoticz.sanity_check()
+        domoticz.sanity_check(args.debug)
     except Exception as e:
         exit_on_error(veolia, domoticz, str(e))
 
@@ -1326,6 +1326,6 @@ if __name__ == "__main__":
     except Exception as e:
         exit_on_error(veolia, domoticz, str(e))
 
-    veolia.clean_up()
+    veolia.clean_up(args.debug)
     o.print("Finished on success")
     sys.exit(0)

--- a/veolia-idf-domoticz.py
+++ b/veolia-idf-domoticz.py
@@ -419,18 +419,19 @@ class VeoliaCrawler:
             else:
                 self.print(st="ok")
 
-        self.print(
-            "Remove temporary download file", end=""
-        )  #############################################################
-        try:
-            os.remove(self.__full_path_download_file)
-        except Exception:
-            raise
-        else:
-            self.print(st="ok")
+        #############################################################
+        if not debug:
+            try:
+                self.print( "Remove temporary download file", end="")
+                os.remove(self.__full_path_download_file)
+            except Exception:
+                raise
+            else:
+                self.print(st="ok")
 
         self.print(
-            'Check if "geckodriver" is intalled properly', end=""
+            'Check if "geckodriver" is installed properly', end=""
+    
         )  #############################################################
         if os.access(self.configuration["geckodriver"], os.X_OK):
             self.print(st="ok")
@@ -442,7 +443,7 @@ class VeoliaCrawler:
             )
 
         self.print(
-            'Check if "firefox" is intalled properly', end=""
+            'Check if "firefox" is installed properly', end=""
         )  #############################################################
         if os.access(self.configuration["firefox"], os.X_OK):
             self.print(st="ok")
@@ -523,22 +524,15 @@ class VeoliaCrawler:
 
         # Remove downloaded file
         try:
-            os.path.exists(self.__full_path_download_file)
-        except:
-            pass
-        else:
-            if os.path.exists(self.__full_path_download_file):
-                self.print(
-                    "Remove downloaded file " + self.download_filename, end=""
-                )  #############################################################
-
+            if not debug and os.path.exists(self.__full_path_download_file):
+                #############################################################
                 # Remove file
-                try:
-                    os.remove(self.__full_path_download_file)
-                except Exception as e:
-                    self.print(str(e), st="EE")
-                else:
-                    self.print(st="ok")
+                self.print( "Remove downloaded file " + self.download_filename, end="")  
+                os.remove(self.__full_path_download_file)
+            else:
+                self.print(st="ok")
+        except Exception as e:
+            self.print(str(e), st="EE")
 
     def get_file(self):
 

--- a/veolia-idf-domoticz.py
+++ b/veolia-idf-domoticz.py
@@ -167,7 +167,7 @@ class Configuration:
 
 
 ################################################################################
-# Object that retrieve the historycal data from Veolia website
+# Object that retrieve the historical data from Veolia website
 ################################################################################
 class VeoliaCrawler:
     site_url = "https://espace-client.vedif.eau.veolia.fr/s/login/"
@@ -500,7 +500,7 @@ class VeoliaCrawler:
             except Exception as e:
                 os.kill(self.__browser.service.process.pid, signal.SIGTERM)
                 self.print(
-                    "selenium didnt properly close the process, so we kill firefox manually (pid="
+                    "selenium didn't properly close the process, so we kill firefox manually (pid="
                     + str(self.__browser.service.process.pid)
                     + ")",
                     "WW",
@@ -639,7 +639,7 @@ class VeoliaCrawler:
 
         ### COMPORTEMENT DIFFERENT S IL S AGIT D UN MULTU CONTRATS OU D U NCONTRAT UNIQUE (CLICK DIRECTEMENT SUR HISTORIQUE)
         self.print(
-            "Wait for MENU contrats or historique", end=""
+            "Wait for MENU contrats or history", end=""
         )  #############################################################
         try:
             ep = EC.visibility_of_element_located(
@@ -701,7 +701,7 @@ class VeoliaCrawler:
                 self.print(st="ok")
 
             self.print(
-                "Wait for historique menu", end=""
+                "Wait for history menu", end=""
             )  #############################################################
             try:
                 ep = EC.visibility_of_element_located(
@@ -719,7 +719,7 @@ class VeoliaCrawler:
                 self.print(st="ok")
 
             self.print(
-                "Click on historique menu", end=""
+                "Click on history menu", end=""
             )  #############################################################
             try:
                 el.click()
@@ -876,7 +876,7 @@ class DomoticzInjector:
         # Generate URL
         url_test = self.configuration["domoticz_server"] + uri
 
-        # Add authentification Items if needed
+        # Add authentication Items if needed
         if self.configuration["domoticz_login"] != "":
             b64domoticz_login = base64.b64encode(
                 self.configuration["domoticz_login"].encode()

--- a/veolia-idf-domoticz.py
+++ b/veolia-idf-domoticz.py
@@ -832,7 +832,7 @@ class VeoliaCrawler:
         t = int(str(self.configuration["timeout"]))
         while t > 0 and not os.path.exists(self.__full_path_download_file):
             time.sleep(1)
-            t - 1
+            t -= 1
         if os.path.exists(self.__full_path_download_file):
             self.print(st="ok")
         else:

--- a/veolia-idf-domoticz.py
+++ b/veolia-idf-domoticz.py
@@ -361,6 +361,11 @@ class VeoliaCrawler:
         # Set Chrome options
         options = webdriver.ChromeOptions()
         options.add_argument("--no-sandbox")
+        options.add_argument("--disable-modal-animations")
+        options.add_argument("--disable-login-animations")
+        options.add_argument("--disable-renderer-backgrounding")
+        options.add_argument("--disable-background-timer-throttling")
+        options.add_argument("--disable-backgrounding-occluded-wndows")
         options.add_experimental_option(
             "prefs",
             {

--- a/veolia-idf-domoticz.py
+++ b/veolia-idf-domoticz.py
@@ -451,7 +451,7 @@ class VeoliaCrawler:
             self.print(st="ok")
 
         self.print(
-            'Check availabilty of "geckodriver"+"firefox" or "chromedriver"+"chromium"', end=""
+            'Check availability of "geckodriver"+"firefox" or "chromedriver"+"chromium"', end=""
 
         )  #############################################################
         if ( os.access(str(self.configuration["geckodriver"]), os.X_OK) and


### PR DESCRIPTION
J'ai évolué veolia-idf pour ajouter le support pour Home Assistant.

- J'ai corrigé quelques petites fautes de langues vivantes.
- J'ai ajouté un "Dockerfile" pour pouvoir lancer le projet sous docker.
- J'ai ajouté un fichier de configuration pour 'pre-commit' (`pip install pre-commit` puis `pre-commit run -a` pour voir les messages du linter).  J'ai mis plusieurs taches en mode manuel pour ne pas trop modifier les fichiers sources.  Idéalement elles seraient activés.
- J'ai maintenu les fichiers téléchargés en cas de débogue.
- J'ai appliqué divers modifications pour limiter les messages de pylint et mypy.
- Et j'ai mis à jour le code pour Home Assistant.



Documentation sommaire:
- Fonctionnement principalement similaire à la documentation sous README.md .
- Intégré sous veolia-idf-domoticz.py .
- Utiliser "config.json.exemple.home-assistant" comme point de départ.
- Créer un Jeton de longue durée sur https://my.home-assistant.io/redirect/profile et le définir comme "ha_token".
- Possibilité d'utiliser `dockerRun.BAT` sous Windows à condition d'installer Docker.
- Le script créera "sensor.veolia_N°CONTRAT_meter_total" et "sensor.veolia_N°CONTRAT_meter_period_total" comme entités sous Home Assistant.
