### PR TITLE
fix basic auth (domoticz new version)

### DIFF
--- a/veolia-idf-domoticz.py
+++ b/veolia-idf-domoticz.py
@@ -825,28 +825,19 @@ class DomoticzInjector:
             retries=1, timeout=int(str(self.configuration["timeout"]))
         )
 
+        self.headers = urllib3.make_headers()
+
     def open_url(self, uri, data=None):  # pylint: disable=unused-argument
         # Generate URL
         url_test = str(self.configuration["domoticz_server"]) + uri
 
-        # Add Authentication Items if needed
-        if self.configuration["domoticz_login"] != "":
-            b64domoticz_login = base64.b64encode(
-                str(self.configuration["domoticz_login"]).encode()
-            )
-            b64domoticz_password = base64.b64encode(
-                str(self.configuration["domoticz_password"]).encode()
-            )
-            url_test = (
-                url_test
-                + "&username="
-                + b64domoticz_login.decode()
-                + "&password="
-                + b64domoticz_password.decode()
-            )
+        if self.configuration["domoticz_login"] != "" and self.configuration["domoticz_password"] != "":
+            http_auth = ':'.join((self.configuration["domoticz_login"] , self.configuration["domoticz_password"] ))
+
+            self.headers.update(urllib3.make_headers(basic_auth=http_auth))
 
         try:
-            response = self.__http.request("GET", url_test)
+            response = self.__http.request("GET", url_test, headers=self.headers)
         except urllib3.exceptions.MaxRetryError as e:
             # HANDLE CONNECTIVITY ERROR
             raise RuntimeError("url=" + url_test + " : " + str(e))


### PR DESCRIPTION
Due to domoticz new version, it's not allowed anymore to pass credentials in the url itself.
It must be done with basic auth using headers.

This PR to use headers and no more credentials in the URL