### PR TITLE
Mise à jour chromedriver

### DIFF
--- a/veolia-idf-domoticz.py
+++ b/veolia-idf-domoticz.py
@@ -52,6 +52,7 @@ try:
     from selenium.webdriver.firefox.service import Service as FirefoxService
     from selenium.webdriver.support import expected_conditions as EC
     from selenium.webdriver.support.ui import WebDriverWait
+    from selenium.webdriver.chrome.service import Service
 except ImportError as exc:
     print(
         "Error: failed to import python required module : " + str(exc),
@@ -407,8 +408,9 @@ class VeoliaCrawler:
             "Start the browser", end=""
         )  #############################################################
         try:
+            service = Service(executable_path=self.configuration["chromedriver"])
             self.__browser = webdriver.Chrome(
-                executable_path=self.configuration["chromedriver"],
+                service=service,
                 options=options,
             )
             self.__browser.maximize_window()


### PR DESCRIPTION
Depuis la version 4.10.0 de Selenium il n'y a plus la variable "executable_path". Pour le setter il faut passer par l'argument "Service". https://github.com/SeleniumHQ/selenium/commit/9f5801c82fb3be3d5850707c46c3f8176e3ccd8e